### PR TITLE
Fix arrhythmia messages when there are multiple jobs in a batch

### DIFF
--- a/lib/resque/plugins/batch.rb
+++ b/lib/resque/plugins/batch.rb
@@ -136,7 +136,7 @@ module Resque
 
               running_jobs.reject(&:heartbeat_running?).each do |batch_job|
                 decoded_msg = {"job_id" => batch_job.job_id, "msg" => "arrhythmia"}
-                batch_jobs[job_id].process_job_msg(decoded_msg)
+                batch_job.process_job_msg(decoded_msg)
                 message_handler.send_message(self, :job, decoded_msg)
               end
             end


### PR DESCRIPTION
Arrhythmia messages would only be sent to the most recent job that sent a message, rather than the job that actually stopped sending heartbeats
Split into two commits - first commit adds a failing test case, and the second commit fixes the bug and makes the test pass
Fixes #15 