### PR TITLE
Remove check for queued jobs

### DIFF
--- a/lib/resque/plugins/batch.rb
+++ b/lib/resque/plugins/batch.rb
@@ -66,20 +66,12 @@ module Resque
           raise "redis list #{batch_key} is not empty"
         end
 
-        expected_queue_jobs = {}
-
         redis.multi do
           batch_jobs.each_with_index do |batch_job, job_id|
             klass = batch_job.klass
             queue = Resque.queue_from_class(klass) || batch_queue
             args = batch_job.args
             args = [id, job_id] + args
-
-            expected_queue_jobs[queue] ||= []
-            expected_queue_jobs[queue] << {
-              'class' => klass.name,
-              'args' => args
-            }
 
             if Resque.inline
               begin
@@ -91,23 +83,6 @@ module Resque
               # rubocop:enable Lint/SuppressedException
             else
               Resque::Job.create(queue, klass, *args)
-            end
-          end
-        end
-
-        unless Resque.inline
-          # Get all the jobs in each queue, then confirm that the jobs we
-          # just queued up are all present
-          expected_queue_jobs.each do |queue_name, expected_jobs|
-            currently_queued_jobs =
-              redis.lrange("queue:#{queue_name}", 0, -1)
-                   .map(&Resque.method(:decode))
-
-            unqueued_jobs =
-              expected_jobs.reject { |job_hash| currently_queued_jobs.include?(job_hash) }
-
-            if unqueued_jobs.any?
-              raise "#{unqueued_jobs.size} job(s) were unable to be queued to the #{queue_name.inspect} queue"
             end
           end
         end


### PR DESCRIPTION
It is not thread-safe since Resque workers can take jobs out of the queue before the check can run

I would expect to get an error from Redis anyway if something failed to be queued

Followup to #19